### PR TITLE
Attempt to resolve paths that point within packages

### DIFF
--- a/lib/live-resolver/index.js
+++ b/lib/live-resolver/index.js
@@ -97,7 +97,7 @@ function clickHandler(e) {
 
       return loader(urls, {type: 'HEAD'}, function(err, body, url) {
         if (err) {
-          $target.attr('aria-label', SORRY);
+          resolveLive();
           return;
         }
         $target.attr('aria-label', RESOLVED);
@@ -105,21 +105,25 @@ function clickHandler(e) {
       });
     }
 
-    loader(util.format(LIVE_RESOLVER, data.type, data.value), {type: 'GET'}, function(err, body) {
-      if (err) {
-        if (data.type === 'npm') {
-          return openUrl(util.format(NPM_API, data.value), newWindow);
+    resolveLive();
+
+    function resolveLive () {
+      loader(util.format(LIVE_RESOLVER, data.type, data.value), {type: 'GET'}, function(err, body) {
+        if (err) {
+          if (data.type === 'npm') {
+            return openUrl(util.format(NPM_API, data.value), newWindow);
+          }
+          $target.attr('aria-label', SORRY);
         }
+
+        if (body.url) {
+          $target.attr('aria-label', RESOLVED);
+          return openUrl(body.url, newWindow);
+        }
+
         $target.attr('aria-label', SORRY);
-      }
-
-      if (body.url) {
-        $target.attr('aria-label', RESOLVED);
-        return openUrl(body.url, newWindow);
-      }
-
-      $target.attr('aria-label', SORRY);
-    });
+      });
+    }
   }
 }
 

--- a/lib/live-resolver/index.js
+++ b/lib/live-resolver/index.js
@@ -53,6 +53,24 @@ function openUrl(url, newWindow) {
   global.open(url, target);
 }
 
+function resolveLive (data, newWindow, $target) {
+  loader(util.format(LIVE_RESOLVER, data.type, data.value), {type: 'GET'}, function(err, body) {
+    if (err) {
+      if (data.type === 'npm') {
+        return openUrl(util.format(NPM_API, data.value), newWindow);
+      }
+      $target.attr('aria-label', SORRY);
+    }
+
+    if (body.url) {
+      $target.attr('aria-label', RESOLVED);
+      return openUrl(body.url, newWindow);
+    }
+
+    $target.attr('aria-label', SORRY);
+  });
+}
+
 function clickHandler(e) {
   var newWindow = (e.metaKey || e.ctrlKey || e.which === 2);
   var $target = $(e.currentTarget);
@@ -97,7 +115,7 @@ function clickHandler(e) {
 
       return loader(urls, {type: 'HEAD'}, function(err, body, url) {
         if (err) {
-          resolveLive();
+          resolveLive(data, newWindow, $target);
           return;
         }
         $target.attr('aria-label', RESOLVED);
@@ -105,25 +123,7 @@ function clickHandler(e) {
       });
     }
 
-    resolveLive();
-
-    function resolveLive () {
-      loader(util.format(LIVE_RESOLVER, data.type, data.value), {type: 'GET'}, function(err, body) {
-        if (err) {
-          if (data.type === 'npm') {
-            return openUrl(util.format(NPM_API, data.value), newWindow);
-          }
-          $target.attr('aria-label', SORRY);
-        }
-
-        if (body.url) {
-          $target.attr('aria-label', RESOLVED);
-          return openUrl(body.url, newWindow);
-        }
-
-        $target.attr('aria-label', SORRY);
-      });
-    }
+    resolveLive(data, newWindow, $target);
   }
 }
 


### PR DESCRIPTION
Together with github-linker/live-resolver#3, this will allow
github-linker/chrome-extension to resolve require calls like:

```javascript
require.resolve('readable-stream/passthrough.js');
```

The following can be used as a test page:

https://github.com/substack/node-browserify/blob/11.1.0/lib/builtins.js#L24-L28

EDIT: remaining test failures are the same as in https://github.com/github-linker/core/pull/23#issuecomment-139823216