### PR TITLE
Fix: module names not resolving due to space

### DIFF
--- a/lib/util/util.js
+++ b/lib/util/util.js
@@ -15,7 +15,7 @@ var urlMatch = function(url, lookup) {
 };
 
 var stripQuotes = function(jqElement) {
-  return jqElement.text().replace(/"|'/g, '');
+  return jqElement.text().replace(/"|'/g, '').trim();
 };
 
 var showLoader = function($) {

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -62,6 +62,10 @@ describe('util', function() {
     it('"lodash\'', function() {
       utils.stripQuotes({text: function(){return '"lodash\'';}}).should.equal('lodash');
     });
+
+    it(' lodash ', function() {
+      utils.stripQuotes({text: function(){return ' lodash ';}}).should.equal('lodash');
+    });
   });
 
   // TODO implement test for


### PR DESCRIPTION
Issue: Try to use Github-linker here in this file,

https://github.com/namshi/roger/blob/master/src/client/components/buildHistory.jsx

Clicking on react leads to https://www.npmjs.com/package/%20react because of the extra space.